### PR TITLE
feat(pre-trigger): support pre_trigger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ An emoji source for [blink.cmp](https://github.com/Saghen/blink.cmp).
           module = "blink-emoji",
           name = "Emoji",
           score_offset = 15, -- Tune by preference
+          ---@type blink-emoji.config
           opts = {
-            insert = true, -- Insert emoji (default) or complete its name
-            ---@type string|table|fun():table
+            insert = true,
+            pre_trigger = function()
+              return { "", " ", "\t" }
+            end,
             trigger = function()
               return { ":" }
             end,


### PR DESCRIPTION

`pre_trigger` is a an array of characters (or function that returns one) which must be present before the trigger characters to actually include emojis in completion suggestions.
It will better de-clutter completion menu. There is probably a better way, but it seems sufficient for now.

Closes #3 .